### PR TITLE
作成者用ページ実装

### DIFF
--- a/lib/createModelPage.dart
+++ b/lib/createModelPage.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class CreateModelPage extends StatefulWidget {
+  const CreateModelPage({super.key});
+
+  @override
+  State<CreateModelPage> createState() => _CreateModelPage();
+}
+
+class _CreateModelPage extends State<CreateModelPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Text('カメラを起動してモデルを作成するページです')
+        ],
+      ),
+    );
+  }
+}

--- a/lib/customDrawer.dart
+++ b/lib/customDrawer.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:hack_3d_create_app/qrReaderPage.dart';
-import './modelCreatorPage.dart';
-import './myHomePage.dart';
+
 class CustomDrawer extends StatefulWidget {
   const CustomDrawer({super.key});
 

--- a/lib/customDrawer.dart
+++ b/lib/customDrawer.dart
@@ -37,8 +37,8 @@ class _CustomDrawerState extends State<CustomDrawer> {
           listTile('ホーム', Icons.home, context, '/'),
           listTile('作成者用', Icons.create, context, '/creator'),
           listTile('3Dモデル表示', Icons.qr_code_scanner, context, '/qr'),
-          //listTile('3Dモデル作成', Icons., context, ''),
-          //listTile('3Dモデル確認', Icons., context, ''),
+          listTile('3Dモデル作成', Icons.camera_alt, context, '/create-model'),
+          listTile('3Dモデル確認', Icons.folder, context, '/list'),
         ],
       ),
     );

--- a/lib/listModelPage.dart
+++ b/lib/listModelPage.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class ListModelPage extends StatefulWidget {
+  const ListModelPage({super.key});
+
+  @override
+  State<ListModelPage> createState() => _ListModelPage();
+}
+
+class _ListModelPage extends State<ListModelPage> {
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Text('作成したモデルを一覧表示するページです')
+        ],
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,9 @@ import './modelCreatorPage.dart';
 import './header.dart';
 import './myHomePage.dart';
 import './customDrawer.dart';
+import './createModelPage.dart';
+import './listModelPage.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -26,6 +29,8 @@ class MyApp extends StatelessWidget {
           '/': (context) => const MainScreen(title: 'ホーム', child: MyHomePage(),isHome: true),
           '/creator': (context) => const MainScreen(title: '作成者用', child: ModelCreatorPage(),isHome: false, backRoute: '/'),//isHome: 戻るボタンの有無, backRoute: 戻るボタンの遷移先
           '/qr': (context) => const MainScreen(title: 'QR読み取り', child: QrReaderPage(),isHome: false, backRoute: '/'),
+          '/list': (context) => const MainScreen(title: '保存したモデル一覧', child: ListModelPage(), isHome: false, backRoute: '/creator'),
+          '/create-model': (context) => const MainScreen(title: 'モデル作成画面', child: CreateModelPage(), isHome: false, backRoute: '/creator')
         },
     );
   }

--- a/lib/modelCreatorPage.dart
+++ b/lib/modelCreatorPage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import './selectButton.dart';
 
 class ModelCreatorPage extends StatefulWidget {
   const ModelCreatorPage({super.key});
@@ -14,7 +15,14 @@ class _ModelCreatorPage extends State<ModelCreatorPage> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          Text('作成者用ページです')
+          SelectButton(
+              buttonText: '3Dモデル作成',
+              iconPath: 'images/カメラアイコン.png',
+              nextPage: '/create-model'),
+          SelectButton(
+              buttonText: '3Dモデル確認',
+              iconPath: 'images/お皿アイコン.png',
+              nextPage: '/list')
         ],
       ),
     );


### PR DESCRIPTION
## 対応内容

- 作成者用のページを実装
- ハンバーガーメニューに仮に作った3Dモデルの作成と確認のページのリンクを追加

## その他

- カメラを起動するページでヘッダーを表示させるかどうかは要検討
